### PR TITLE
Add keys to PUBG crate spark lanes

### DIFF
--- a/src/components/PUBGCrate.tsx
+++ b/src/components/PUBGCrate.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+type PUBGCrateItem = {
+  id: string | number;
+  name: string;
+  rarity: string;
+  imageUrl: string;
+};
+
+type PUBGCrateProps = {
+  stagedItems: PUBGCrateItem[];
+};
+
+export const PUBGCrate: React.FC<PUBGCrateProps> = ({ stagedItems }) => {
+  if (!stagedItems?.length) {
+    return null;
+  }
+
+  return (
+    <div className="pubg-crate">
+      <div className="pubg-crate__spark-columns" aria-hidden>
+        {stagedItems.map((item, index) => (
+          <span
+            key={`${item.id}-${index}`}
+            className="pubg-crate__spark-column"
+            data-lane-index={index}
+          />
+        ))}
+      </div>
+      <ol className="pubg-crate__items">
+        {stagedItems.map((item) => (
+          <li key={item.id} className={`pubg-crate__item pubg-crate__item--${item.rarity}`}>
+            <img src={item.imageUrl} alt={item.name} />
+            <span className="pubg-crate__item-name">{item.name}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+export default PUBGCrate;


### PR DESCRIPTION
## Summary
- add a PUBG crate component that renders spark columns with unique keys for each staged item
- expose each spark column's index via a data attribute for potential lane-specific styling
- include placeholder item rendering so the component can display the staged items list

## Testing
- not run (project setup not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd980282a88333800de062092128a0