### PR TITLE
Fix duplicate keys for PUBG crate sparks

### DIFF
--- a/frontend/src/components/PUBGCrate.tsx
+++ b/frontend/src/components/PUBGCrate.tsx
@@ -120,8 +120,8 @@ export function PUBGCrate({ pool, result, triggerKey, isAnimating, onComplete }:
           <div className="pubg-crate__strap pubg-crate__strap--right" />
           <motion.div className="pubg-crate__glow" animate={glowControls} />
             <motion.div className="pubg-crate__sparks" animate={sparksControls}>
-              {stagedItems.map((item) => (
-                <span key={item.id} />
+              {stagedItems.map((item, index) => (
+                <span key={`${item.id}-${index}`} data-spark-index={index} />
               ))}
             </motion.div>
             {result && (


### PR DESCRIPTION
## Summary
- ensure spark spans use an id-index key combination to prevent duplicates
- expose each spark's index as a data attribute for future styling needs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cda2e18d5c8333997c15c8235dfe04