### PR TITLE
Align loot animations with in-game layouts

### DIFF
--- a/frontend/src/components/CS2Roller.css
+++ b/frontend/src/components/CS2Roller.css
@@ -16,16 +16,22 @@
 
 .cs2-roller__track {
   position: relative;
+  width: min(1020px, 100%);
+  height: 265px;
+  display: flex;
+  align-items: center;
   overflow: hidden;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   background:
-    linear-gradient(120deg, rgba(25, 36, 60, 0.92), rgba(14, 20, 36, 0.88)),
+    linear-gradient(135deg, rgba(7, 10, 18, 0.92), rgba(4, 6, 12, 0.98)),
     radial-gradient(140% 110% at 15% 50%, rgba(87, 129, 255, 0.12), transparent 65%);
   box-shadow:
+    0 40px 70px rgba(0, 0, 0, 0.5),
     inset 0 0 0 1px rgba(255, 255, 255, 0.04),
     inset 0 20px 38px -28px rgba(0, 0, 0, 0.9),
     0 22px 40px -34px rgba(5, 9, 20, 0.8);
+  backdrop-filter: blur(10px);
 }
 
 .cs2-roller__track::before {
@@ -36,6 +42,190 @@
   pointer-events: none;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0));
   opacity: 0.6;
+}
+
+.cs2-roller__track::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 215, 141, 0) 0%,
+    rgba(255, 215, 141, 0.22) 50%,
+    rgba(255, 215, 141, 0) 100%
+  );
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.cs2-roller__track[data-active='true']::after {
+  opacity: 0.6;
+}
+
+.cs2-roller__spool {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 420px;
+  will-change: transform;
+}
+
+.cs2-roller__card {
+  position: relative;
+  width: 220px;
+  height: 200px;
+  border-radius: 20px;
+  border: 2px solid color-mix(in srgb, var(--card-border, #8791a5) 70%, rgba(255, 255, 255, 0.1));
+  background: linear-gradient(
+    135deg,
+    var(--card-primary, #2a3a62),
+    color-mix(in srgb, var(--card-secondary, #1a233a) 70%, #000 30%)
+  );
+  padding: 1.1rem 1.15rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  color: var(--card-text, #f7f8ff);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.32);
+  overflow: hidden;
+}
+
+.cs2-roller__card::before {
+  content: '';
+  position: absolute;
+  inset: -25%;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.55), transparent 55%);
+  opacity: 0.4;
+  mix-blend-mode: screen;
+}
+
+.cs2-roller__card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--card-glow, rgba(255, 255, 255, 0.16));
+  opacity: 0.25;
+  mix-blend-mode: screen;
+}
+
+.cs2-roller__card.pattern-stripes::after,
+.cs2-roller__card.pattern-grid::after,
+.cs2-roller__card.pattern-pulse::after,
+.cs2-roller__card.pattern-spark::after,
+.cs2-roller__card.pattern-carbon::after,
+.cs2-roller__card.pattern-plasma::after {
+  background-size: 280%;
+}
+
+.cs2-roller__card.pattern-stripes::after {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.4) 0px,
+    rgba(255, 255, 255, 0.4) 14px,
+    transparent 14px,
+    transparent 36px
+  );
+}
+
+.cs2-roller__card.pattern-grid::after {
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.25) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.25) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+.cs2-roller__card.pattern-pulse::after {
+  background-image: radial-gradient(circle at 60% 40%, rgba(255, 255, 255, 0.5) 0%, transparent 55%);
+}
+
+.cs2-roller__card.pattern-spark::after {
+  background-image:
+    radial-gradient(circle at 15% 15%, rgba(255, 255, 255, 0.55) 0, transparent 45%),
+    radial-gradient(circle at 85% 35%, rgba(255, 255, 255, 0.55) 0, transparent 60%),
+    radial-gradient(circle at 35% 80%, rgba(255, 255, 255, 0.4) 0, transparent 65%);
+}
+
+.cs2-roller__card.pattern-carbon::after {
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.35) 0px, rgba(255, 255, 255, 0.05) 14px);
+  background-size: 18px 18px;
+}
+
+.cs2-roller__card.pattern-plasma::after {
+  background-image:
+    radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.65) 0, transparent 40%),
+    radial-gradient(circle at 70% 70%, rgba(255, 255, 255, 0.55) 0, transparent 60%);
+}
+
+.cs2-roller__card-rarity {
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  opacity: 0.75;
+}
+
+.cs2-roller__card-name {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-top: auto;
+}
+
+.cs2-roller__card-meta {
+  font-size: 0.7rem;
+  opacity: 0.8;
+  margin-top: 0.35rem;
+}
+
+.cs2-roller__card--result {
+  box-shadow: inset 0 0 60px rgba(255, 255, 255, 0.35), 0 0 40px rgba(255, 215, 141, 0.45);
+}
+
+.cs2-roller__highlight {
+  position: absolute;
+  top: 32px;
+  bottom: 36px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 220px;
+  border-radius: 18px;
+  border: 2px solid rgba(255, 215, 141, 0.75);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 215, 141, 0.22) 0%,
+    rgba(255, 215, 141, 0.08) 50%,
+    rgba(255, 215, 141, 0) 100%
+  );
+  box-shadow: 0 0 46px rgba(255, 215, 141, 0.35);
+  pointer-events: none;
+}
+
+.cs2-roller__pointer {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  pointer-events: none;
+}
+
+.cs2-roller__pointer span:first-of-type {
+  width: 0;
+  height: 0;
+  border-left: 16px solid transparent;
+  border-right: 16px solid transparent;
+  border-bottom: 20px solid rgba(255, 215, 141, 0.95);
+  filter: drop-shadow(0 0 12px rgba(255, 215, 141, 0.55));
+}
+
+.cs2-roller__pointer span:last-of-type {
+  width: 62px;
+  height: 4px;
+  background: linear-gradient(90deg, rgba(255, 215, 141, 0), rgba(255, 215, 141, 0.95), rgba(255, 215, 141, 0));
 }
 
 .cs2-roller__window {
@@ -95,205 +285,41 @@
   color: rgba(230, 236, 255, 0.72);
 }
 
+/* ---------- Tablets (<= 900px) ---------- */
+@media (max-width: 900px) {
+  .cs2-roller__spool {
+    padding: 0 320px;
+  }
+}
+
 /* ---------- Mobile (<= 768px) ---------- */
 @media (max-width: 768px) {
   .cs2-roller {
     padding: 1.25rem;
   }
 
-  .cs2-roller__items {
-    padding: 0.9rem 1rem;
-  }
-
-  /* Das hier war fälschlich unter __items gemerged: gehört zum Track */
   .cs2-roller__track {
-    width: min(1020px, 100%);
-    height: 265px;
-    border-radius: 26px;
-    background: linear-gradient(135deg, rgba(7, 10, 18, 0.92), rgba(4, 6, 12, 0.98));
-    overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    box-shadow: 0 40px 70px rgba(0, 0, 0, 0.5);
-    backdrop-filter: blur(10px);
-  }
-
-  /* Der „active“-Scan-Effekt nur auf Mobile, um das globale ::before nicht zu überschreiben */
-  .cs2-roller__track::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(
-      90deg,
-      rgba(255, 215, 141, 0) 0%,
-      rgba(255, 215, 141, 0.22) 50%,
-      rgba(255, 215, 141, 0) 100%
-    );
-    opacity: 0;
-    transition: opacity 200ms ease;
-    pointer-events: none;
-  }
-
-  .cs2-roller__track[data-active='true']::after {
-    opacity: 0.6;
+    height: 240px;
+    border-radius: 22px;
   }
 
   .cs2-roller__spool {
-    display: flex;
-    align-items: center;
-    height: 100%;
-    padding: 0 420px;
-    will-change: transform;
-  }
-
-  .cs2-roller__card {
-    position: relative;
-    width: 220px;
-    height: 200px;
-    border-radius: 20px;
-    border: 2px solid color-mix(in srgb, var(--card-border, #8791a5) 70%, rgba(255, 255, 255, 0.1));
-    background: linear-gradient(
-      135deg,
-      var(--card-primary, #2a3a62),
-      color-mix(in srgb, var(--card-secondary, #1a233a) 70%, #000 30%)
-    );
-    padding: 1.1rem 1.15rem;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    color: var(--card-text, #f7f8ff);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.32);
-    overflow: hidden;
-  }
-
-  .cs2-roller__card::before {
-    content: '';
-    position: absolute;
-    inset: -25%;
-    background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.55), transparent 55%);
-    opacity: 0.4;
-    mix-blend-mode: screen;
-  }
-
-  .cs2-roller__card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: var(--card-glow, rgba(255, 255, 255, 0.16));
-    opacity: 0.25;
-    mix-blend-mode: screen;
-  }
-
-  .cs2-roller__card.pattern-stripes::after,
-  .cs2-roller__card.pattern-grid::after,
-  .cs2-roller__card.pattern-pulse::after,
-  .cs2-roller__card.pattern-spark::after,
-  .cs2-roller__card.pattern-carbon::after,
-  .cs2-roller__card.pattern-plasma::after {
-    background-size: 280%;
-  }
-
-  .cs2-roller__card.pattern-stripes::after {
-    background-image: repeating-linear-gradient(
-      -45deg,
-      rgba(255, 255, 255, 0.4) 0px,
-      rgba(255, 255, 255, 0.4) 14px,
-      transparent 14px,
-      transparent 36px
-    );
-  }
-
-  .cs2-roller__card.pattern-grid::after {
-    background-image:
-      linear-gradient(rgba(255, 255, 255, 0.25) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(255, 255, 255, 0.25) 1px, transparent 1px);
-    background-size: 22px 22px;
-  }
-
-  .cs2-roller__card.pattern-pulse::after {
-    background-image: radial-gradient(circle at 60% 40%, rgba(255, 255, 255, 0.5) 0%, transparent 55%);
-  }
-
-  .cs2-roller__card.pattern-spark::after {
-    background-image:
-      radial-gradient(circle at 15% 15%, rgba(255, 255, 255, 0.55) 0, transparent 45%),
-      radial-gradient(circle at 85% 35%, rgba(255, 255, 255, 0.55) 0, transparent 60%),
-      radial-gradient(circle at 35% 80%, rgba(255, 255, 255, 0.4) 0, transparent 65%);
-  }
-
-  .cs2-roller__card.pattern-carbon::after {
-    background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.35) 0px, rgba(255, 255, 255, 0.05) 14px);
-    background-size: 18px 18px;
-  }
-
-  .cs2-roller__card.pattern-plasma::after {
-    background-image:
-      radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.65) 0, transparent 40%),
-      radial-gradient(circle at 70% 70%, rgba(255, 255, 255, 0.55) 0, transparent 60%);
-  }
-
-  .cs2-roller__card-rarity {
-    font-size: 0.7rem;
-    letter-spacing: 0.18em;
-    opacity: 0.75;
-  }
-
-  .cs2-roller__card-name {
-    font-size: 1.05rem;
-    font-weight: 700;
-    margin-top: auto;
-  }
-
-  .cs2-roller__card-meta {
-    font-size: 0.7rem;
-    opacity: 0.8;
-    margin-top: 0.35rem;
-  }
-
-  .cs2-roller__card--result {
-    box-shadow: inset 0 0 60px rgba(255, 255, 255, 0.35), 0 0 40px rgba(255, 215, 141, 0.45);
+    padding: 0 260px;
   }
 
   .cs2-roller__highlight {
-    position: absolute;
-    top: 32px;
-    bottom: 36px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 220px;
-    border-radius: 18px;
-    border: 2px solid rgba(255, 215, 141, 0.75);
-    background: linear-gradient(180deg, rgba(255, 215, 141, 0.22) 0%, rgba(255, 215, 141, 0.08) 50%, rgba(255, 215, 141, 0) 100%);
-    box-shadow: 0 0 46px rgba(255, 215, 141, 0.35);
-    pointer-events: none;
-  }
-
-  .cs2-roller__pointer {
-    position: absolute;
-    top: 10px;
-    left: 50%;
-    transform: translateX(-50%);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 3px;
-    pointer-events: none;
+    top: 26px;
+    bottom: 30px;
   }
 
   .cs2-roller__pointer span:first-of-type {
-    width: 0;
-    height: 0;
-    border-left: 16px solid transparent;
-    border-right: 16px solid transparent;
-    border-bottom: 20px solid rgba(255, 215, 141, 0.95);
-    filter: drop-shadow(0 0 12px rgba(255, 215, 141, 0.55));
+    border-left-width: 14px;
+    border-right-width: 14px;
+    border-bottom-width: 18px;
   }
 
   .cs2-roller__pointer span:last-of-type {
-    width: 62px;
-    height: 4px;
-    background: linear-gradient(90deg, rgba(255, 215, 141, 0), rgba(255, 215, 141, 0.95), rgba(255, 215, 141, 0));
+    width: 54px;
   }
 }
 

--- a/frontend/src/components/PUBGCrate.css
+++ b/frontend/src/components/PUBGCrate.css
@@ -60,9 +60,9 @@
 
 .pubg-crate__door {
   position: absolute;
-  left: 50%;
+  left: 5%;
+  right: 5%;
   bottom: 0;
-  width: 90%;
   height: 68px;
   transform-origin: top center;
   transform-style: preserve-3d;
@@ -105,7 +105,10 @@
 
 .pubg-crate__sparks {
   position: absolute;
-  inset: -20% -5% auto -5%;
+  top: -20%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 260px;
   height: 200px;
   pointer-events: none;
   display: flex;


### PR DESCRIPTION
## Summary
- Rebuild the CS2 roller stage styling so the track, cards, highlight window and pointer mirror the in-game presentation on desktop and smaller breakpoints.
- Center the PUBG crate door, sparks and item reveal so the animation lines up with the box opening.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdb07e6a408333b2937fce1c0400f2